### PR TITLE
Set 'no-cache' headers on the current log file on day change.

### DIFF
--- a/smartMeterLogger-esp32.ino
+++ b/smartMeterLogger-esp32.ino
@@ -100,6 +100,7 @@ void updateLogfileHandler(const tm& now) {
 
   static AsyncStaticWebHandler* oldLogFilesHandler;
   http_server.removeHandler(oldLogFilesHandler);
+
   oldLogFilesHandler = &http_server.serveStatic("/", SD, "/").setCacheControl("public, max-age=604800, immutable");
 
   ESP_LOGI(TAG, "'no-cache' headers set on: %s", filename);

--- a/smartMeterLogger-esp32.ino
+++ b/smartMeterLogger-esp32.ino
@@ -97,7 +97,11 @@ void updateLogfileHandler(const tm& now) {
     response->addHeader("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0");
     request->send(response);
   });
-  ESP_LOGI(TAG, "no-cache headers set on: %s", filename);
+
+  static AsyncStaticWebHandler* logFileHandler2 = &http_server.serveStatic("/", SD, "/").setCacheControl("max-age=60000");
+  //logFileHandler2->setCacheControl("max-age=60000");
+
+  ESP_LOGI(TAG, "'no-cache' headers set on: %s", filename);
 }
 
 void setup() {
@@ -145,7 +149,7 @@ void setup() {
   /* sync the clock with ntp */
   configTzTime(TIMEZONE, NTP_POOL);
 
-  struct tm now {
+  tm now {
     0
   };
 
@@ -219,8 +223,6 @@ void setup() {
   */
 
   updateLogfileHandler(now);
-
-  http_server.serveStatic("/", SD, "/").setCacheControl("max-age=60000");
 
   http_server.onNotFound([](AsyncWebServerRequest * request) {
     request->send(404);

--- a/smartMeterLogger-esp32.ino
+++ b/smartMeterLogger-esp32.ino
@@ -94,13 +94,13 @@ void updateLogfileHandler(const tm& now) {
     ESP_LOGI(TAG, "request for current logfile: %s", filename);
     if (!SD.exists(filename)) return request->send(404);
     AsyncWebServerResponse *response = request->beginResponse(SD, filename);
-    response->addHeader("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0");
+    response->addHeader("Cache-Control", "no-store, max-age=0");
     request->send(response);
   });
 
   static AsyncStaticWebHandler* oldLogFilesHandler;
   http_server.removeHandler(oldLogFilesHandler);
-  oldLogFilesHandler = &http_server.serveStatic("/", SD, "/").setCacheControl("max-age=60000");
+  oldLogFilesHandler = &http_server.serveStatic("/", SD, "/").setCacheControl("public, max-age=604800, immutable");
 
   ESP_LOGI(TAG, "'no-cache' headers set on: %s", filename);
 }


### PR DESCRIPTION
Cache headers should be different based on the date.

Todays logfile should not be cached at all.

Cache files from the past should be cached.